### PR TITLE
feat: Add git-scope issue command to open GitHub issues page

### DIFF
--- a/cmd/git-scope/main.go
+++ b/cmd/git-scope/main.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Bharath-code/git-scope/internal/browser"
 	"github.com/Bharath-code/git-scope/internal/config"
 	"github.com/Bharath-code/git-scope/internal/scan"
 	"github.com/Bharath-code/git-scope/internal/tui"
@@ -27,6 +28,7 @@ Commands:
   scan        Scan and print repos (JSON)
   scan-all    Full system scan from home directory (with stats)
   init        Create config file interactively
+  issue       Open git-scope GitHub issues page in browser
   help        Show this help
 
 Examples:
@@ -35,6 +37,7 @@ Examples:
   git-scope scan .             # Scan current directory (JSON)
   git-scope scan-all           # Find ALL repos on your system
   git-scope init               # Setup config interactively
+  git-scope issue              # Open GitHub issues page
 
 Flags:
 `, version)
@@ -61,7 +64,7 @@ func main() {
 	// Parse command and directories
 	if len(args) >= 1 {
 		switch args[0] {
-		case "scan", "tui", "help", "init", "scan-all", "-h", "--help", "-v", "--version":
+		case "scan", "tui", "help", "init", "scan-all", "issue", "-h", "--help", "-v", "--version":
 			cmd = args[0]
 			dirs = args[1:]
 		default:
@@ -86,6 +89,12 @@ func main() {
 	// Handle init command
 	if cmd == "init" {
 		runInit()
+		return
+	}
+
+	// Handle issue command
+	if cmd == "issue" {
+		runIssue()
 		return
 	}
 
@@ -291,6 +300,16 @@ func runInit() {
 	}
 	fmt.Printf("   Editor: %s\n", editor)
 	fmt.Println("\n🚀 Run 'git-scope' to launch the dashboard!")
+}
+
+// runIssue opens the git-scope GitHub issues page in the default browser
+func runIssue() {
+	issuesURL := "https://github.com/Bharath-code/git-scope/issues"
+	if err := browser.Open(issuesURL); err != nil {
+		fmt.Fprintf(os.Stderr, "Failed to open browser: %v\n", err)
+		fmt.Fprintf(os.Stderr, "You can visit the issues page manually at: %s\n", issuesURL)
+		os.Exit(1)
+	}
 }
 
 // runScanAll performs a full system scan starting from home directory

--- a/internal/browser/browser.go
+++ b/internal/browser/browser.go
@@ -1,0 +1,23 @@
+package browser
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+// Open opens a URL in the system default browser
+func Open(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		return fmt.Errorf("unsupported operating system: %s", runtime.GOOS)
+	}
+	return cmd.Run()
+}

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -3,8 +3,8 @@ package tui
 import (
 	"fmt"
 	"os/exec"
-	"runtime"
 
+	"github.com/Bharath-code/git-scope/internal/browser"
 	"github.com/Bharath-code/git-scope/internal/model"
 	"github.com/Bharath-code/git-scope/internal/nudge"
 	"github.com/Bharath-code/git-scope/internal/scan"
@@ -506,18 +506,7 @@ func scanWorkspaceCmd(workspacePath string, ignore []string) tea.Cmd {
 // openBrowserCmd opens a URL in the default browser
 func openBrowserCmd(url string) tea.Cmd {
 	return func() tea.Msg {
-		var cmd *exec.Cmd
-		switch runtime.GOOS {
-		case "darwin":
-			cmd = exec.Command("open", url)
-		case "linux":
-			cmd = exec.Command("xdg-open", url)
-		case "windows":
-			cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
-		default:
-			return nil
-		}
-		_ = cmd.Run()
+		_ = browser.Open(url)
 		return nil
 	}
 }


### PR DESCRIPTION
## Description

Implements the feature requested in #5 - adds a `git-scope issue` command that opens the GitHub issues page in the user's default browser.

Closes #5

## Changes
- Added new `git-scope issue` command to open https://github.com/Bharath-code/git-scope/issues
- Create `/internal/browser` package for cross-platform browser launching
- Refactor TUI's `openBrowserCmd()` to use the shared browser package
- Update help text to document the new command

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated the documentation (if applicable)
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix/feature works (if applicable)
