### PR TITLE
fix: rescan (r) now performs fresh scan instead of returning cached data

### DIFF
--- a/internal/tui/app.go
+++ b/internal/tui/app.go
@@ -22,17 +22,19 @@ func Run(cfg *config.Config) error {
 }
 
 // scanReposCmd is a command that scans for repositories
-func scanReposCmd(cfg *config.Config) tea.Cmd {
+// If forceRefresh is true, bypass cache and scan fresh
+func scanReposCmd(cfg *config.Config, forceRefresh bool) tea.Cmd {
 	return func() tea.Msg {
-		// Try to load from cache first
 		cacheStore := cache.NewFileStore()
-		cached, err := cacheStore.Load()
 
-		if err == nil && cacheStore.IsValid(cacheMaxAge) && cacheStore.IsSameRoots(cfg.Roots) {
-			// Use cached data but trigger background refresh
-			return scanCompleteMsg{
-				repos:     cached.Repos,
-				fromCache: true,
+		// Try to load from cache first (unless forcing refresh)
+		if !forceRefresh {
+			cached, err := cacheStore.Load()
+			if err == nil && cacheStore.IsValid(cacheMaxAge) && cacheStore.IsSameRoots(cfg.Roots) {
+				return scanCompleteMsg{
+					repos:     cached.Repos,
+					fromCache: true,
+				}
 			}
 		}
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -153,7 +153,7 @@ func NewModel(cfg *config.Config) Model {
 
 // Init initializes the model
 func (m Model) Init() tea.Cmd {
-	return tea.Batch(m.spinner.Tick, scanReposCmd(m.cfg))
+	return tea.Batch(m.spinner.Tick, scanReposCmd(m.cfg, false))
 }
 
 // GetSelectedRepo returns the currently selected repo

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -110,7 +110,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			m.statusMsg = ""
 		}
-		return m, scanReposCmd(m.cfg)
+		return m, scanReposCmd(m.cfg, true)
 
 	case grassDataLoadedMsg:
 		m.grassData = msg.data
@@ -182,7 +182,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "r":
 			m.state = StateLoading
 			m.statusMsg = "Rescanning..."
-			return m, scanReposCmd(m.cfg)
+			return m, scanReposCmd(m.cfg, true)
 
 		case "f":
 			// Cycle through filter modes


### PR DESCRIPTION
## Summary
- Fix rescan shortcut (`r`) to bypass cache and fetch fresh git status
- Previously, rescan returned cached data if cache was < 5 minutes old, making it ineffective

## Problem
When pressing `r` to rescan, the app calls `scanReposCmd()` which checks cache first. If the cache is valid (< 5 min) and roots haven't changed, it returns stale data. Users had to quit and restart the app to see updated dirty/clean status.

## Solution
Added `forceRefresh bool` parameter to `scanReposCmd()`:
- `r` (rescan) and workspace switch now pass `true` to bypass cache
- Initial load still passes `false` to benefit from fast cached startup

## Test plan
- [x] Run `git-scope`, note a repo's status
- [x] In another terminal, make a change in that repo (e.g., `touch newfile`)
- [x] Press `r` to rescan — status should update immediately
- [x] Restart app — should still load quickly from cache on startup

🤖 Generated with [Claude Code](https://claude.ai/code)