### PR TITLE
feat: add configurable pageSize option

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,9 +11,10 @@ import (
 
 // Config holds the application configuration
 type Config struct {
-	Roots  []string `yaml:"roots"`
-	Ignore []string `yaml:"ignore"`
-	Editor string   `yaml:"editor"`
+	Roots    []string `yaml:"roots"`
+	Ignore   []string `yaml:"ignore"`
+	Editor   string   `yaml:"editor"`
+	PageSize int      `yaml:"pageSize,omitempty"`
 }
 
 // defaultConfig returns sensible defaults
@@ -37,7 +38,8 @@ func defaultConfig() *Config {
 			".venv",
 			"vendor",
 		},
-		Editor: "code",
+		Editor:   "code",
+		PageSize: 15,
 	}
 }
 
@@ -61,6 +63,11 @@ func Load(path string) (*Config, error) {
 	// Expand ~ in paths
 	for i, root := range cfg.Roots {
 		cfg.Roots[i] = expandPath(root)
+	}
+
+	// Ensure pageSize has a sensible value
+	if cfg.PageSize <= 0 {
+		cfg.PageSize = 15
 	}
 
 	return cfg, nil

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -147,7 +147,7 @@ func NewModel(cfg *config.Config) Model {
 		sortMode:       SortByDirty,
 		filterMode:     FilterAll,
 		currentPage:    0,
-		pageSize:       15,
+		pageSize:       cfg.PageSize,
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `pageSize` config option to customize repos displayed per page
- Default remains 15 for backward compatibility

## Problem
The page size (15 repos per page) was hardcoded. Users with many repos or larger screens may want to see more repos at once without paginating.

## Solution
Added `pageSize` field to the config struct:

```yaml
# ~/.config/git-scope/config.yml
roots:
  - ~/code
editor: code
pageSize: 25
```

**Implementation details:**
- New `PageSize int` field in `Config` struct with `yaml:"pageSize,omitempty"` tag
- Default value of 15 set in `defaultConfig()`
- Validation ensures sensible value (falls back to 15 if ≤ 0)
- `NewModel()` now reads from `cfg.PageSize` instead of hardcoded value

## Test plan
- [ ] Run without `pageSize` in config — should show 15 repos per page (default)
- [ ] Add `pageSize: 25` to config — should show 25 repos per page
- [ ] Set `pageSize: 0` — should fall back to 15 (default)
- [ ] Verify pagination controls (`[` / `]`) still work correctly

---
This PR was created by Claude (claude.ai)