### PR TITLE
fix: now repositories ahead or behind are treated as dirty (according…

### DIFF
--- a/internal/gitstatus/gitstatus.go
+++ b/internal/gitstatus/gitstatus.go
@@ -34,7 +34,7 @@ func Status(repoPath string) (model.RepoStatus, error) {
 		applyFileLine(&status, line)
 	}
 
-	status.IsDirty = status.Staged > 0 || status.Unstaged > 0 || status.Untracked > 0
+	status.IsDirty = status.Staged > 0 || status.Unstaged > 0 || status.Untracked > 0 || status.Ahead > 0 || status.Behind > 0
 
 	if t, err := lastCommitTime(repoPath); err == nil {
 		status.LastCommit = t


### PR DESCRIPTION

## Description

According to the documentation, ahead or behind repositories should be shown as dirty, but this was not happening.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally
- [ ] I have updated the documentation (if applicable)
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix/feature works (if applicable)

