### PR TITLE
feat: dynamically adjust page size based on terminal height

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -371,4 +371,11 @@ func (m *Model) resizeTable() {
 		h = 1
 	}
 	m.table.SetHeight(h)
+
+	// Ensure page size is at least 5 to avoid too small pages
+	if h < 5 {
+		h = 5
+	}
+	m.pageSize = h  // Update page size based on new height
+	m.updateTable() // Refresh table to apply new page size
 }


### PR DESCRIPTION
## Description

The page size was hardcoded to 15 repos per page regardless of terminal size. This updates `resizeTable()` to dynamically set `pageSize` based on available terminal height, so larger terminals show more repos and smaller ones show fewer. Minimum page size is capped at 5.

Fixes #17

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally
- [ ] I have updated the documentation (if applicable)
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix/feature works (if applicable)