### PR TITLE
dynamic page height and sync version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.2] - 2026-06-20
+
+### Changed
+- Repo list now fills the full available terminal height instead of a fixed page size
+- Page size adjusts automatically on terminal resize, search bar open/close, and filter/sort changes
+- Removed `pageSize` config option — page size is determined entirely by terminal height
+

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ git-scope -h           # Show help
   * **📁 Workspace Switch** — Switch root directories without quitting (`w`). Supports `~`, relative paths, and **symlinks**.
   * **🔍 Fuzzy Search** — Find any repo by name, path, or branch (`/`).
   * **🛡️ Dirty Filter** — Instantly show only repos with uncommitted changes (`f`).
-  * **📄 Pagination** — Navigate large repo lists with page-by-page browsing (`[` / `]`). Shows 15 repos per page with a dynamic page indicator.
+  * **📄 Pagination** — Navigate large repo lists with page-by-page browsing (`[` / `]`). The list fills the available terminal height, with a dynamic page indicator when there are more repos than fit on screen.
   * **🚀 Editor Jump** — Open the selected repo in VSCode, Neovim, Vim, or Helix (`Enter`).
   * **⚡ Blazing Fast** — JSON caching ensures \~10ms launch time even with 50+ repos.
   * **📊 Dashboard Stats** — See branch name, staged/unstaged counts, and last commit time.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,10 +11,9 @@ import (
 
 // Config holds the application configuration
 type Config struct {
-	Roots    []string `yaml:"roots"`
-	Ignore   []string `yaml:"ignore"`
-	Editor   string   `yaml:"editor"`
-	PageSize int      `yaml:"pageSize,omitempty"`
+	Roots  []string `yaml:"roots"`
+	Ignore []string `yaml:"ignore"`
+	Editor string   `yaml:"editor"`
 }
 
 // defaultConfig returns sensible defaults
@@ -38,8 +37,7 @@ func defaultConfig() *Config {
 			".venv",
 			"vendor",
 		},
-		Editor:   "code",
-		PageSize: 15,
+		Editor: "code",
 	}
 }
 
@@ -63,11 +61,6 @@ func Load(path string) (*Config, error) {
 	// Expand ~ in paths
 	for i, root := range cfg.Roots {
 		cfg.Roots[i] = expandPath(root)
-	}
-
-	// Ensure pageSize has a sensible value
-	if cfg.PageSize <= 0 {
-		cfg.PageSize = 15
 	}
 
 	return cfg, nil

--- a/internal/nudge/nudge.go
+++ b/internal/nudge/nudge.go
@@ -4,10 +4,9 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-)
 
-// Version is the current app version - used to track per-version nudge
-const Version = "1.3.0"
+	"github.com/Bharath-code/git-scope/internal/version"
+)
 
 // GitHubRepoURL is the URL to open when user presses S
 const GitHubRepoURL = "https://github.com/Bharath-code/git-scope"
@@ -78,7 +77,7 @@ func ShouldShowNudge() bool {
 	state := loadState()
 
 	// Already seen for this version
-	if state.SeenVersion == Version {
+	if state.SeenVersion == version.Version {
 		return false
 	}
 
@@ -93,7 +92,7 @@ func ShouldShowNudge() bool {
 // MarkShown marks the nudge as shown for the current version
 func MarkShown() {
 	state := loadState()
-	state.SeenVersion = Version
+	state.SeenVersion = version.Version
 	state.Dismissed = false
 	_ = saveState(state)
 }
@@ -101,7 +100,7 @@ func MarkShown() {
 // MarkDismissed marks the nudge as dismissed (any key pressed)
 func MarkDismissed() {
 	state := loadState()
-	state.SeenVersion = Version
+	state.SeenVersion = version.Version
 	state.Dismissed = true
 	_ = saveState(state)
 }
@@ -109,7 +108,7 @@ func MarkDismissed() {
 // MarkCompleted marks the nudge as completed (S pressed, GitHub opened)
 func MarkCompleted() {
 	state := loadState()
-	state.SeenVersion = Version
+	state.SeenVersion = version.Version
 	state.Completed = true
 	_ = saveState(state)
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -148,8 +148,7 @@ func NewModel(cfg *config.Config) Model {
 		state:          StateLoading,
 		sortMode:       SortByDirty,
 		filterMode:     FilterAll,
-		currentPage:    0,
-		pageSize:       cfg.PageSize,
+		currentPage: 0,
 	}
 }
 
@@ -361,7 +360,7 @@ func formatNumber(n int) string {
 	return fmt.Sprintf("%d", n)
 }
 
-// resizeTable calculates and sets the correct table height based on UI state
+// resizeTable calculates and sets the correct table height based on UI state.
 func (m *Model) resizeTable() {
 	usedHeight := 12 // Header + Stats + Legend + Help + Padding
 	if m.state == StateSearching {
@@ -369,7 +368,6 @@ func (m *Model) resizeTable() {
 	} else if m.searchQuery != "" {
 		usedHeight += 1 // Search badge
 	}
-
 	h := m.height - usedHeight
 	if h < 1 {
 		h = 1
@@ -380,6 +378,6 @@ func (m *Model) resizeTable() {
 	if h < 5 {
 		h = 5
 	}
-	m.pageSize = h  // Update page size based on new height
-	m.updateTable() // Refresh table to apply new page size
+	m.pageSize = h
+	m.updateTable()
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -148,7 +148,7 @@ func NewModel(cfg *config.Config) Model {
 		state:          StateLoading,
 		sortMode:       SortByDirty,
 		filterMode:     FilterAll,
-		currentPage: 0,
+		currentPage:    0,
 	}
 }
 

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -38,7 +38,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.repos = msg.repos
 		m.state = StateReady
 		m.resetPage()
-		m.updateTable()
+		m.resizeTable()
 
 		// Show helpful message if no repos found
 		if len(msg.repos) == 0 {
@@ -59,7 +59,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.repos = msg.repos
 		m.state = StateReady
 		m.resetPage()
-		m.updateTable()
+		m.resizeTable()
 
 		// Show helpful message about switched workspace
 		if len(msg.repos) == 0 {
@@ -189,7 +189,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == StateReady {
 				m.filterMode = (m.filterMode + 1) % 3
 				m.resetPage()
-				m.updateTable()
+				m.resizeTable()
 				m.statusMsg = "Filter: " + m.GetFilterModeName()
 				return m, nil
 			}
@@ -198,7 +198,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == StateReady {
 				m.sortMode = (m.sortMode + 1) % 4
 				m.resetPage()
-				m.updateTable()
+				m.resizeTable()
 				m.statusMsg = "Sorted by: " + m.GetSortModeName()
 				return m, nil
 			}
@@ -207,7 +207,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == StateReady {
 				m.sortMode = SortByDirty
 				m.resetPage()
-				m.updateTable()
+				m.resizeTable()
 				m.statusMsg = "Sorted by: Dirty First"
 				return m, nil
 			}
@@ -216,7 +216,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == StateReady {
 				m.sortMode = SortByName
 				m.resetPage()
-				m.updateTable()
+				m.resizeTable()
 				m.statusMsg = "Sorted by: Name"
 				return m, nil
 			}
@@ -225,7 +225,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == StateReady {
 				m.sortMode = SortByBranch
 				m.resetPage()
-				m.updateTable()
+				m.resizeTable()
 				m.statusMsg = "Sorted by: Branch"
 				return m, nil
 			}
@@ -234,7 +234,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.state == StateReady {
 				m.sortMode = SortByLastCommit
 				m.resetPage()
-				m.updateTable()
+				m.resizeTable()
 				m.statusMsg = "Sorted by: Recent"
 				return m, nil
 			}
@@ -247,7 +247,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.filterMode = FilterAll
 				m.resetPage()
 				m.resizeTable()
-				m.updateTable()
 				m.statusMsg = "Filters cleared"
 				return m, nil
 			}
@@ -372,10 +371,9 @@ func (m Model) handleSearchMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		// Apply search
 		m.searchQuery = m.textInput.Value()
 		m.state = StateReady
-		m.resizeTable()
 		m.textInput.Blur()
 		m.resetPage()
-		m.updateTable()
+		m.resizeTable()
 		if m.searchQuery != "" {
 			m.statusMsg = "Searching: " + m.searchQuery
 		} else {

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Bharath-code/git-scope/internal/version"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -104,8 +105,8 @@ func (m Model) renderDashboard() string {
 
 	// Header with logo on its own line
 	logo := lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("#A78BFA")).Render("git-scope")
-	version := lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render(" v1.3.0")
-	b.WriteString(logo + version)
+	ver := lipgloss.NewStyle().Foreground(lipgloss.Color("#6B7280")).Render(" v" + version.Version)
+	b.WriteString(logo + ver)
 	b.WriteString("\n\n")
 
 	// Stats bar (always show first for consistent layout)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+const Version = "1.3.2"


### PR DESCRIPTION
## Description

- 🐛[fix] Synchronized version numbers so they are all the same: **1.3.2**
  - `nudge.go` and `view.go` showed **1.3.0** but `main.go` still had **1.0.1** so `git-scope -v` returned **1.0.1** while the header showed **1.3.0**
  - Now all use `internal/version/version.go` to prevent drift
  - The code showed version `1.3.0` but the latest release said `1.3.1` so I went with `1.3.2`.
- ✨ [new] Repo list now fills the full available terminal height instead of a fixed page size
- ✨ [new] Page size adjusts automatically on terminal resize, search bar open/close, and filter/sort changes
- 🔧 [change] Removed `pageSize` config option - it didn't work consistently, and is the wrong approach since the terminal window size can change. Now page size is determined entirely by terminal height

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)
  - Technically I took out the old `pageSize` config option
- [x] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes)

## Checklist

- [x] I have tested my changes locally
- [x] I have updated the documentation (if applicable)
- [x] My code follows the project's style guidelines
- [ ] I have added tests that prove my fix/feature works (if applicable)

## Screenshots (if applicable)

<img width="1626" height="942" alt="image" src="https://github.com/user-attachments/assets/aa47ea4b-d618-40ab-9031-01c9bb30977b" />
